### PR TITLE
Fixes #2 adds openssl to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:21-jdk
+RUN microdnf install openssl
 VOLUME /tmp
 ADD target/signservice-integration-rest.jar /opt/signservice/
 ADD start.sh /opt/signservice/


### PR DESCRIPTION
For the new docker image `2.3.1`.